### PR TITLE
Adding suffix to resource names, so that resource creation does not fail

### DIFF
--- a/002__intermediate-workshop/cfn/opea.yaml
+++ b/002__intermediate-workshop/cfn/opea.yaml
@@ -35,12 +35,12 @@ Resources:
                 Action:
                   - 'ssm:GetParameter'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/huggingface/api_token'
-      RoleName: 'SSMforEC2'
+      RoleName: !Sub SSMforEC2-${AWS::StackName}
 
   SSMforEC2InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      InstanceProfileName: 'SSMforEC2InstanceProfile'
+      InstanceProfileName: !Sub SSMforEC2InstanceProfile-${AWS::StackName}
       Roles:
         - !Ref 'SSMforEC2Role'
 

--- a/002__intermediate-workshop/cfn/openvino.yaml
+++ b/002__intermediate-workshop/cfn/openvino.yaml
@@ -32,14 +32,14 @@ Resources:
                 Action:
                   - 'ssm:GetParameter'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/huggingface/api_token'
-      RoleName: 'SSMforEC2'
+      RoleName: !Sub SSMforEC2-${AWS::StackName}
 
   SSMforEC2InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
-      InstanceProfileName: 'SSMforEC2InstanceProfile'
+      InstanceProfileName: !Sub SSMforEC2InstanceProfile-${AWS::StackName}
       Roles:
-        - !Ref 'SSMforEC2Role'
+        - !Ref 'SSMforEC2Role' 
   EC2SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
While running both the templates. I encountered an error due to the resource names being the same.

So, I added the stack name as the suffix on the following resources causing problem

Old names:

RoleName: 'SSMforEC2'
InstanceProfileName: 'SSMforEC2InstanceProfile'

new names:

RoleName: !Sub SSMforEC2-${AWS::StackName}
InstanceProfileName: !Sub SSMforEC2InstanceProfile-${AWS::StackName}

what was SSMforEC2 will now be SSMforEC2-openvino / SSMforEC2-opea

CloudFormation stack names do not allow characters that are disallowed in IAM role names (e.g., /, *, spaces), using AWS::StackName as a suffix in an IAM role name will not cause issues related to invalid characters